### PR TITLE
fix for issue #16

### DIFF
--- a/telegraff-core/src/main/kotlin/me/ruslanys/telegraff/core/dto/request/keyboard/TelegramRemoveReplyKeyboard.kt
+++ b/telegraff-core/src/main/kotlin/me/ruslanys/telegraff/core/dto/request/keyboard/TelegramRemoveReplyKeyboard.kt
@@ -2,12 +2,9 @@ package me.ruslanys.telegraff.core.dto.request.keyboard
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-class TelegramRemoveReplyKeyboard : TelegramReplyKeyboard() {
-
-    @JsonProperty("remove_keyboard")
-    fun getRemoveKeyboard(): Boolean {
-        return true
-    }
+class TelegramRemoveReplyKeyboard(
+    @get:JsonProperty("remove_keyboard") val removeKeyboard: Boolean = false
+) : TelegramReplyKeyboard() {
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -20,6 +17,5 @@ class TelegramRemoveReplyKeyboard : TelegramReplyKeyboard() {
     override fun hashCode(): Int {
         return super.hashCode()
     }
-
 
 }


### PR DESCRIPTION
Фикс для проблемы с клавиатурой, в дефолтном состоянии надо указывать `"remove_keyboard": false` и тогда все ок никакой проблемы с 400 ошибкой нет